### PR TITLE
Handle all SocketChannel.connect() exceptions

### DIFF
--- a/hawtdispatch-transport/src/main/java/org/fusesource/hawtdispatch/transport/TcpTransport.java
+++ b/hawtdispatch-transport/src/main/java/org/fusesource/hawtdispatch/transport/TcpTransport.java
@@ -454,13 +454,16 @@ public class TcpTransport extends ServiceBase implements Transport {
                                         readSource.setCancelHandler(CANCEL_HANDLER);
                                         readSource.resume();
 
-                                    } catch (IOException e) {
+                                    } catch (Exception e) {
                                         try {
                                             channel.close();
-                                        } catch (IOException ignore) {
+                                        } catch (Exception ignore) {
                                         }
                                         socketState = new CANCELED(true);
-                                        listener.onTransportFailure(e);
+                                        if (! (e instanceof IOException)) {
+                                            e = new IOException(e);
+                                        }
+                                        listener.onTransportFailure((IOException)e);
                                     }
                                 }
                             });


### PR DESCRIPTION
I built an MQTT client using mqtt-client.  To test its resiliency, I turned off the WiFi on my laptop while it was connected and subscribed.  It noticed the connection fail and tried to reconnect, but that never returned (using the CallbackConnection, never called back with failure or success), even after I turned the WiFi back on.  The console did report a java.nio.channels.UnresolvedAddressException exception at TcpTransport:432.  (Presumably because DNS is unavailable with the network off).  This is not caught by the try-catch established at 426, because it's not an IOException. Thus the listener is not notified of the failure at 463.  Instead, the (unchecked) exception is thrown back to the creator of the thread, which reports it as an unexpected exception.

My fix was to catch all exceptions.  This solves the problem, and the program now processes the failure correctly.   There may of course be other parts of the code which would benefit from a  similar change.

Thanks,
Mike

(This is Java 1.6.0_45 on MacOS 10.7.5 .  It's not clear to me if different environments would produce different exceptions.)
