### PR TITLE
Do not even invoke getLocalHost() if not necessary

### DIFF
--- a/hawtdispatch-transport/src/main/java/org/fusesource/hawtdispatch/transport/TcpTransport.java
+++ b/hawtdispatch-transport/src/main/java/org/fusesource/hawtdispatch/transport/TcpTransport.java
@@ -507,9 +507,9 @@ public class TcpTransport extends ServiceBase implements Transport {
     }
 
     protected String resolveHostName(String host) throws UnknownHostException {
-        String localName = getLocalHost().getHostName();
-        if (localName != null && isUseLocalHost()) {
-            if (localName.equals(host)) {
+        if (isUseLocalHost()) {
+            String localName = getLocalHost().getHostName();
+            if (localName != null && localName.equals(host)) {
                 return "localhost";
             }
         }


### PR DESCRIPTION
Some systems are getting exceptions from getLocalHost() and
setting isUseLocalHost() had no positive effect on them.
