### PR TITLE
Add shutdown() to Dispatcher interface

### DIFF
--- a/hawtdispatch/src/main/java/org/fusesource/hawtdispatch/Dispatcher.java
+++ b/hawtdispatch/src/main/java/org/fusesource/hawtdispatch/Dispatcher.java
@@ -184,4 +184,8 @@ public interface Dispatcher {
      */
     public List<Metrics> metrics();
 
+    /**
+     * Request that all dispatcher queues and workers be shut down gracefully.
+     */
+    public void shutdown();
 }


### PR DESCRIPTION
I wire up Dispatcher through Spring Configuration annotations, and want to
give Dispatcher a chance to shutdown gracefully when Spring is shutting
down. Since shutdown() isn't part of the Dispatcher interface, I get
warnings about a method that doesn't exist.

This adds shutdown() to the interface to fix that warning.

The usage of this in my Spring Configuration is:

    @Bean(destroyMethod="shutdown")
    public Dispatcher hawtDispatcher() {
        return DispatcherConfig.getDefaultDispatcher();
    }