### PR TITLE
CANCELING.onCanceled() never triggered when being stopped before connecting

### DIFF
--- a/hawtdispatch-transport/src/main/java/org/fusesource/hawtdispatch/transport/TcpTransport.java
+++ b/hawtdispatch-transport/src/main/java/org/fusesource/hawtdispatch/transport/TcpTransport.java
@@ -129,7 +129,8 @@ public class TcpTransport extends ServiceBase implements Transport {
         }
         void onCanceled() {
             trace("CANCELING.onCanceled");
-            remaining--;
+            // it could be zero when neither readSource nor writeSource has been initialized yet
+            if (remaining > 0) remaining--;
             if( remaining!=0 ) {
                 return;
             }
@@ -463,6 +464,10 @@ public class TcpTransport extends ServiceBase implements Transport {
                                 public void run() {
                                     // No need to complete if we have been canceled.
                                     if( ! socketState.is(CONNECTING.class) ) {
+                                        // fire onCanceled() for CANCELLING state. otherwise, it will never be triggered
+                                        if ( socketState.is(CANCELING.class)) {
+                                    		socketState.onCanceled();
+                                    	}
                                         return;
                                     }
                                     try {


### PR DESCRIPTION
Consider the case when `TcpTransport.stop()` is called just after a `TcpTransport.start()` call. There is a chance that the `socketState` becomes `CANCELING` which is changed by the `TcpTransport.stop()` call. The following logic would prevent it from connecting and doing any further initialization. In this scenario, the `CANCELING.onCanceled()` would never be triggered after that, which means the `onCompleted` Task of the `TcpTransport.stop()` parameter would never be triggered as well. As a result, the client will wait forever if it relies on the `onCompleted` Task to be called to proceed.

```
// No need to complete if we have been canceled.
if( ! socketState.is(CONNECTING.class) ) {
    return;
}
```
